### PR TITLE
Changes configmap resource to kubernetes_config_map_v1_data

### DIFF
--- a/aws-auth-configmap.tf
+++ b/aws-auth-configmap.tf
@@ -1,6 +1,8 @@
-resource "kubernetes_config_map" "aws_auth" {
+# kubernetes_config_map will fail because the configmap already exists
+resource "kubernetes_config_map_v1_data" "aws_auth" {
   count = var.create_eks ? 1 : 0
-
+  # By using force, we overwrite the keys
+  force = true
   metadata {
     name      = "aws-auth"
     namespace = "kube-system"


### PR DESCRIPTION
Replaces [configmap](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) with [configmap_data](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data)
Configmap will have a conflict with the pre-existing configmap. By using config_map_v1_data we can overwrite whatever the configmap has.